### PR TITLE
sliently advertise https for rstudio & add index file for esrumweb0?fl

### DIFF
--- a/esrum/source/services/r.rst
+++ b/esrum/source/services/r.rst
@@ -199,8 +199,8 @@ you and press enter:
  RStudio servers
 *****************
 
-The RStudio_ servers can be found at http://esrumweb01fl:8787/ and
-http://esrumweb02fl:8787/. To connect to this server, you must
+The RStudio_ servers can be found at https://esrumweb01fl/rstudio/ and
+https://esrumweb02fl/rstudio/. To connect to this server, you must
 
 #. Be a member of the ``SRV-esrumweb-users`` group. Simply follow the
    steps in the :ref:`s_applying_for_access` section, and apply for
@@ -211,7 +211,7 @@ http://esrumweb02fl:8787/. To connect to this server, you must
 
 Once you have been been made a member of the ``SRV-esrumweb-users`` and
 connected using the VPN or a wired connection at CBMR, simply visit
-http://esrumweb01fl:8787/ or http://esrumweb02fl:8787/ and login using
+https://esrumweb01fl/rstudio/ or https://esrumweb02fl/rstudio/ and login using
 your UCPH credentials.
 
 For your username you should use the short form:

--- a/root/esrumwebroot.html
+++ b/root/esrumwebroot.html
@@ -1,0 +1,296 @@
+<!DOCTYPE html>
+<html lang='en'>
+
+<head>
+    <meta charset='utf-8'>
+    <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+    <title>CBMR Data Analytics</title>
+    <link rel='stylesheet' href='https://unpkg.com/purecss@2.1.0/build/pure-min.css'
+        integrity='sha384-yHIFVG6ClnONEA5yB5DJXfW2/KC173DIQrYoZMEtBvGzmf0PKiGyNEqe9N6BNDBH' crossorigin='anonymous'>
+    <style type='text/css'>
+        body {
+            background-color: #E3E2DE;
+        }
+
+        div#layout {
+            max-width: 920px;
+            margin-left: auto;
+            margin-right: auto;
+            font-size: smaller;
+        }
+
+        div.title {
+            color: white;
+            background-color: #901a1e;
+
+            margin: -10px !important;
+            text-align: center;
+            border-radius: 5px;
+        }
+
+        h2>a:any-link {
+            color: white;
+        }
+
+        div.pure-u-2-5>div {
+            margin: 5px !important;
+        }
+
+        div.pure-u-2-5>p {
+            margin: 15px !important;
+        }
+
+        div>p {
+            font-size: medium !important;
+        }
+
+        div.pure-g {
+            justify-content: center;
+        }
+
+        p {
+            text-align: center;
+        }
+
+        div.title>h1,
+        div.title>h2 {
+            padding: 5px;
+        }
+
+        .section {
+            background-color: #FFF;
+            border-radius: 5px;
+            margin-bottom: 10px;
+            padding: 10px;
+            padding-top: 0px;
+        }
+
+        svg {
+            vertical-align: top;
+        }
+    </style>
+</head>
+
+<body>
+    <div id='layout'>
+        <div class="pure-g">
+            <div class="pure-u-2-5">
+                <div class="title narrow-title">
+                    <h2>
+                        <!-- Copyright Halal Labs (2024); see below -->
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"
+                            color="#ffffff" fill="none">
+                            <path
+                                d="M11 2H10C6.72077 2 5.08116 2 3.91891 2.81382C3.48891 3.1149 3.1149 3.48891 2.81382 3.91891C2 5.08116 2 6.72077 2 10C2 13.2792 2 14.9188 2.81382 16.0811C3.1149 16.5111 3.48891 16.8851 3.91891 17.1862C5.08116 18 6.72077 18 10 18H14C17.2792 18 18.9188 18 20.0811 17.1862C20.5111 16.8851 20.8851 16.5111 21.1862 16.0811C21.8652 15.1114 21.9777 13.8094 21.9963 11.5"
+                                stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+                            <path
+                                d="M13 6.66667C13 7.95533 14.0074 9 15.25 9H19.975C21.0934 9 22 8.0598 22 6.9C22 5.7402 21.0833 4.80003 19.9649 4.80003C20.0897 3.36433 18.9799 2 17.5 2C16.2055 2 15.143 3.03069 15.0342 4.34393C13.8928 4.45657 13 5.45349 13 6.66667Z"
+                                stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                stroke-linejoin="round" />
+                            <path d="M11 15H13" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                stroke-linejoin="round" />
+                            <path d="M12 18V22" stroke="currentColor" stroke-width="2" />
+                            <path d="M8 22H16" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+                        </svg>
+
+                        <a href="/rstudio/">Login to Rstudio</a>
+
+                    </h2>
+                </div>
+            </div>
+        </div>
+                <div class="title">
+            <h1>CBMR Data Analytics</h1>
+        </div>
+        <div class="section">
+            <p style="padding-top: 15px;">The <a href="https://cbmr.ku.dk/research-facilities/data-analytics/">Data
+                    Analytics Platform</a> at the Novo Nordisk Foundation
+                <a href="https://cbmr.ku.dk/">Center for Basic Metabolic
+                    Research</a> enables scientists and collaborators at the
+                center to seamlessly integrate multidimensional,
+                high-resolution data from diverse sources in a
+                state-of-the-art computing environment.
+            </p>
+            <p>For this purpose, the Data Analytics Platform makes
+                available the following resources:</p>
+            <div class="pure-g">
+                <div class="pure-u-2-5">
+                    <div class="title narrow-title">
+                        <h2>
+                            <!-- Copyright Halal Labs (2024); see below -->
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"
+                                color="#ffffff" fill="none">
+                                <path
+                                    d="M11 2H10C6.72077 2 5.08116 2 3.91891 2.81382C3.48891 3.1149 3.1149 3.48891 2.81382 3.91891C2 5.08116 2 6.72077 2 10C2 13.2792 2 14.9188 2.81382 16.0811C3.1149 16.5111 3.48891 16.8851 3.91891 17.1862C5.08116 18 6.72077 18 10 18H14C17.2792 18 18.9188 18 20.0811 17.1862C20.5111 16.8851 20.8851 16.5111 21.1862 16.0811C21.8652 15.1114 21.9777 13.8094 21.9963 11.5"
+                                    stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+                                <path
+                                    d="M13 6.66667C13 7.95533 14.0074 9 15.25 9H19.975C21.0934 9 22 8.0598 22 6.9C22 5.7402 21.0833 4.80003 19.9649 4.80003C20.0897 3.36433 18.9799 2 17.5 2C16.2055 2 15.143 3.03069 15.0342 4.34393C13.8928 4.45657 13 5.45349 13 6.66667Z"
+                                    stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                    stroke-linejoin="round" />
+                                <path d="M11 15H13" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                    stroke-linejoin="round" />
+                                <path d="M12 18V22" stroke="currentColor" stroke-width="2" />
+                                <path d="M8 22H16" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+                            </svg>
+
+                            <a href="https://cbmr-data.github.io/esrum/">HPC
+                                Cluster</a>
+
+                        </h2>
+                    </div>
+                    <p>The HPC cluster "Esrum" is available to all employees
+                        at CBMR, as well as their collaborators.</p>
+                    <p>Click <a href="https://cbmr-data.github.io/esrum/">here</a> for
+                        documentation about how to gain access to and use the
+                        cluster.</p>
+                </div>
+                <div class="pure-u-2-5">
+                    <div class="title narrow-title">
+                        <h2>
+                            <!-- Copyright Halal Labs (2024); see below -->
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"
+                                color="#ffffff" fill="none">
+                                <path d="M2 6L6 6.00003" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                    stroke-linejoin="round" />
+                                <path d="M2 13H6" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                    stroke-linejoin="round" />
+                                <path d="M2 21H21" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                    stroke-linejoin="round" />
+                                <path
+                                    d="M19.4 13.4L22 16M20.7 8.85C20.7 5.6191 18.0809 3 14.85 3C11.6191 3 9 5.6191 9 8.85C9 12.0809 11.6191 14.7 14.85 14.7C18.0809 14.7 20.7 12.0809 20.7 8.85Z"
+                                    stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                    stroke-linejoin="round" />
+                            </svg>
+
+                            <a href="https://cbmrcat.unicph.domain/">Cohort Catalog</a>
+                        </h2>
+                    </div>
+                    <p>The cohort catalog provides an overview of human
+                        cohort data managed by Data Analytics.</p>
+                    <p>Click <a href="https://cbmrcat.unicph.domain/">here</a> to
+                        access the catalog. The catalog is only accessible to CBMR employees using the
+                        UCPH <a href="https://kunet.ku.dk/employee-guide/Pages/IT/Remote-access.aspx">
+                            VPN</a>.
+                    </p>
+                </div>
+            </div>
+            <div class="pure-g">
+                <div class="pure-u-2-5">
+                    <div class="title narrow-title">
+                        <h2>
+                            <!-- Copyright Halal Labs (2024); see below -->
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"
+                                color="#ffffff" fill="none">
+                                <path d="M10 20.5675C6.57143 21.7248 3.71429 20.5675 2 17" stroke="currentColor"
+                                    stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                                <path
+                                    d="M10 22V18.7579C10 18.1596 10.1839 17.6396 10.4804 17.1699C10.6838 16.8476 10.5445 16.3904 10.1771 16.2894C7.13394 15.4528 5 14.1077 5 9.64606C5 8.48611 5.38005 7.39556 6.04811 6.4464C6.21437 6.21018 6.29749 6.09208 6.31748 5.9851C6.33746 5.87813 6.30272 5.73852 6.23322 5.45932C5.95038 4.32292 5.96871 3.11619 6.39322 2.02823C6.39322 2.02823 7.27042 1.74242 9.26698 2.98969C9.72282 3.27447 9.95075 3.41686 10.1515 3.44871C10.3522 3.48056 10.6206 3.41384 11.1573 3.28041C11.8913 3.09795 12.6476 3 13.5 3C14.3524 3 15.1087 3.09795 15.8427 3.28041C16.3794 3.41384 16.6478 3.48056 16.8485 3.44871C17.0493 3.41686 17.2772 3.27447 17.733 2.98969C19.7296 1.74242 20.6068 2.02823 20.6068 2.02823C21.0313 3.11619 21.0496 4.32292 20.7668 5.45932C20.6973 5.73852 20.6625 5.87813 20.6825 5.9851C20.7025 6.09207 20.7856 6.21019 20.9519 6.4464C21.6199 7.39556 22 8.48611 22 9.64606C22 14.1077 19.8661 15.4528 16.8229 16.2894C16.4555 16.3904 16.3162 16.8476 16.5196 17.1699C16.8161 17.6396 17 18.1596 17 18.7579V22"
+                                    stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                    stroke-linejoin="round" />
+                            </svg>
+
+                            <a href="https://github.com/cbmr-data">Software</a>
+                        </h2>
+                    </div>
+                    <p>Open-source software developed by Data Analytics is
+                        hosted on our GitHub page.</p>
+                    <p>Click <a href="https://github.com/cbmr-data">here</a>
+                        to view our projects.</p>
+                </div>
+                <div class="pure-u-2-5">
+                    <div class="title narrow-title">
+                        <h2>
+                            <!-- Copyright Halal Labs (2024); see below -->
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"
+                                color="#ffffff" fill="none">
+                                <path d="M12 22L10 16H2L4 22H12ZM12 22H16" stroke="currentColor" stroke-width="2"
+                                    stroke-linecap="round" stroke-linejoin="round" />
+                                <path
+                                    d="M12 13V12.5C12 10.6144 12 9.67157 11.4142 9.08579C10.8284 8.5 9.88562 8.5 8 8.5C6.11438 8.5 5.17157 8.5 4.58579 9.08579C4 9.67157 4 10.6144 4 12.5V13"
+                                    stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                    stroke-linejoin="round" />
+                                <path
+                                    d="M19 13C19 14.1046 18.1046 15 17 15C15.8954 15 15 14.1046 15 13C15 11.8954 15.8954 11 17 11C18.1046 11 19 11.8954 19 13Z"
+                                    stroke="currentColor" stroke-width="2" />
+                                <path
+                                    d="M10 4C10 5.10457 9.10457 6 8 6C6.89543 6 6 5.10457 6 4C6 2.89543 6.89543 2 8 2C9.10457 2 10 2.89543 10 4Z"
+                                    stroke="currentColor" stroke-width="2" />
+                                <path d="M14 17.5H20C21.1046 17.5 22 18.3954 22 19.5V20C22 21.1046 21.1046 22 20 22H19"
+                                    stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+                            </svg>
+
+                            <a href="https://cbmr-data.github.io/esrum/contact.html">
+                                Support
+                            </a>
+                        </h2>
+                    </div>
+                    <p>
+                        Data Analytics provides support in person, via
+                        email, and via Slack.
+                    </p>
+                    <p>Click <a href="https://cbmr-data.github.io/esrum/contact.html">here</a>
+                        for information about how to contact us.</p>
+                </div>
+                <div class="pure-u-2-5">
+                    <div class="title narrow-title">
+                        <h2>
+                            <!-- Copyright Halal Labs (2024); see below -->
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"
+                                color="#ffffff" fill="none">
+                                <path
+                                    d="M4.26781 18.8447C4.49269 20.515 5.87613 21.8235 7.55966 21.9009C8.97627 21.966 10.4153 22 12 22C13.5847 22 15.0237 21.966 16.4403 21.9009C18.1239 21.8235 19.5073 20.515 19.7322 18.8447C19.879 17.7547 20 16.6376 20 15.5C20 14.3624 19.879 13.2453 19.7322 12.1553C19.5073 10.485 18.1239 9.17649 16.4403 9.09909C15.0237 9.03397 13.5847 9 12 9C10.4153 9 8.97627 9.03397 7.55966 9.09909C5.87613 9.17649 4.49269 10.485 4.26781 12.1553C4.12104 13.2453 4 14.3624 4 15.5C4 16.6376 4.12104 17.7547 4.26781 18.8447Z"
+                                    stroke="currentColor" stroke-width="2" />
+                                <path d="M7.5 9V6.5C7.5 4.01472 9.51472 2 12 2C13.9593 2 15.5 3.5 16 5"
+                                    stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                    stroke-linejoin="round" />
+                                <path d="M11.9961 15.5H12.0051" stroke="currentColor" stroke-width="2"
+                                    stroke-linecap="round" stroke-linejoin="round" />
+                            </svg>
+
+                            <a
+                                href="https://cbmr-data.github.io/esrum/guidelines.html#access-to-protected-data-by-staff">
+                                Data-access Policy
+                            </a>
+                        </h2>
+                    </div>
+                    <p>
+                        The Data Access Platform may require access to protected data under certain circumstances.
+                    </p>
+
+                    <p>Click <a
+                            href="https://cbmr-data.github.io/esrum/guidelines.html#access-to-protected-data-by-staff">here</a>
+                        to view our policies.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+    <p style="font-size: smaller; text-align: center; color: grey;">
+        This page was built using <a href="https://purecss.io/">Pure</a> and <a
+            href="https://github.com/hugeicons/hugeicons-react">hugeicons</a>.</p>
+</body>
+
+</html>
+
+<!--
+The svg (hugeicons) used on this page are licensed under the MIT license:
+
+Copyright (c) 2024 Halal Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->


### PR DESCRIPTION
Creating this pull request mainly for your information. 

I've change to the new https links in the documentation already and added a separate manually created file in /root/ for now that serves as index.html on the two machines already. It's the root page with "login to Rstudio" as local link at the top. Looks like all other links are working fine as is. 

I've pushed the file to the machines with `rsync esrumwebroot.html esrumweb02fl:/usr/share/nginx/html/index.html`. The nginx/html directory is made writable by svr-esrumweb-admin, so you can do the same, if you ever want to update it.