### PR TITLE
don't run pre-commmit twice on main branch

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -3,8 +3,6 @@ name: pre-commit
 on:
   pull_request:
   workflow_call:
-  push:
-    branches: [ main ]
 
 permissions:
   contents: read


### PR DESCRIPTION
It is already run as part of the publish workflow