### PR TITLE
indicate where to run code-blocks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,11 @@ repos:
       - id: docstrfmt
         types_or: [rst]
         args: ["--line-length", "72", "--file-type", "rst", "--ignore-cache", "--check"]
+  # Check that all `.. code-block` directives include a `:class:`, etc.
+  - repo: local
+    hooks:
+      - id: rst-checks
+        name: rst-check
+        entry: python3 ./scripts/rst_checks.py
+        language: python
+        files: "\\.rst$"

--- a/esrum/source/_static/css/code-blocks.css
+++ b/esrum/source/_static/css/code-blocks.css
@@ -1,0 +1,44 @@
+/**
+ * For use with a code-block; indicates command to be On the user's
+ * own computer, not on Esrum.
+ */
+.local-command {
+    position: relative;
+}
+
+.local-command::after {
+    content: "On your computer";
+}
+
+/**
+ * For use with a code-block; indicates command to be On Esrum, not
+ * on the user's own computer.
+ */
+.remote-command {
+    position: relative;
+}
+
+.remote-command::after {
+    content: "On Esrum";
+}
+
+/** Use `:class: generic-command` for code-blocks in neither category */
+
+/** Common formatting for command labels */
+.local-command::after,
+.remote-command::after {
+    position: absolute;
+    bottom: 4px;
+    right: 4px;
+    font-size: 0.6rem;
+    font-weight: bold;
+    color: var(--color-background-primary);
+    background-color: var(--color-foreground-primary);
+    opacity: 0.5;
+    border-radius: 10px;
+    corner-shape: scoop;
+    padding-left: 4px;
+    padding-right: 4px;
+    padding-top: 1px;
+    padding-bottom: 1px;
+}

--- a/esrum/source/conf.py
+++ b/esrum/source/conf.py
@@ -53,6 +53,7 @@ html_theme_options = {
 
 html_static_path = ["_static"]
 html_css_files = [
+    "css/code-blocks.css",
     "css/playback.css",
     "css/theme.css",
 ]

--- a/esrum/source/resources/modules.rst
+++ b/esrum/source/resources/modules.rst
@@ -33,6 +33,7 @@ This is accomplished with the ``module avail`` command, that lists all
 available modules by default:
 
 .. code-block:: console
+    :class: remote-command
 
     $ module avail
     -------------------------- /opt/software/modules --------------------------
@@ -46,6 +47,7 @@ available modules by default:
 The ``avail`` command can also be used to list module versions by name:
 
 .. code-block:: console
+    :class: remote-command
 
     $ module avail samtools
     -------------------------- /opt/software/modules --------------------------
@@ -59,6 +61,7 @@ If you are not sure of the exact name of a module, then the ``search``
 command can be used to search module names and descriptions:
 
 .. code-block:: console
+    :class: remote-command
 
     $ module search conda
      -------------------------- /opt/software/modules ---------------------------
@@ -89,6 +92,7 @@ adds the executable to your PATH and performs any other setup required
 to run the software.
 
 .. code-block:: console
+    :class: remote-command
 
     $ samtools
     -bash: samtools: command not found
@@ -102,6 +106,7 @@ Specifying the exact version of a module that you want to load is highly
 recommended. This ensures that your results are reproducible:
 
 .. code-block:: console
+    :class: remote-command
 
     $ module load samtools/1.12
     $ samtools
@@ -122,6 +127,7 @@ recommended. This ensures that your results are reproducible:
 In some cases one module will require another module:
 
 .. code-block:: console
+    :class: remote-command
 
     $ module load bcftools/1.16
     Loading bcftools/1.16
@@ -132,6 +138,7 @@ In that case you simply need to load the required module first. This can
 be done in done manually:
 
 .. code-block:: console
+    :class: remote-command
 
     $ module load perl
     $ module load bcftools/1.16
@@ -139,6 +146,7 @@ be done in done manually:
 Or automatically:
 
 .. code-block:: console
+    :class: remote-command
 
     $ module load --auto bcftools
     Loading bcftools/1.16
@@ -151,6 +159,7 @@ Some modules require additional steps before you can use them. If so,
 then this is typically described in the ``module display`` text:
 
 .. code-block:: console
+    :class: remote-command
     :emphasize-lines: 11
 
     $ module display cellect/1.0
@@ -170,6 +179,7 @@ Thus, if we wanted to use ``cellect/1.0``, we would need to perform the
 following steps:
 
 .. code-block:: console
+    :class: remote-command
 
     $ module display cellect/1.0
     $ module load miniconda/4.12.0
@@ -191,6 +201,7 @@ The modules you have loaded can be listed using the ``module list``
 command:
 
 .. code-block:: console
+    :class: remote-command
 
     $ modules list
     Currently Loaded Modulefiles:
@@ -200,6 +211,7 @@ To remove a module that you no longer need, use the ``module unload``
 command to unload a single module:
 
 .. code-block:: console
+    :class: remote-command
 
     $ module unload samtools
 
@@ -207,6 +219,7 @@ Alternatively, you can use the ``module purge`` command to unload all
 modules:
 
 .. code-block:: console
+    :class: remote-command
 
     $ module purge
     $ modules list
@@ -237,6 +250,7 @@ To export a list of your currently used models, use the following
 command:
 
 .. code-block:: console
+    :class: remote-command
 
     $ module config collection_pin_version 1
     $ module save ./modules.txt
@@ -255,6 +269,7 @@ If used correctly, the ``./modules.txt`` file will contain the currently
 loaded modules, e.g:
 
 .. code-block:: console
+    :class: remote-command
 
     $ module list
     Currently Loaded Modulefiles:
@@ -272,6 +287,7 @@ To load the saved modules, simply run ``module restore`` with the same
 filename (and a directory component):
 
 .. code-block:: console
+    :class: remote-command
 
     $ module list
     No Modulefiles Currently Loaded.
@@ -285,12 +301,14 @@ the content of the file in your current shell. This has the same effect
 as running ``module restore``:
 
 .. code-block:: console
+    :class: remote-command
 
     $ . ./modules.txt
 
 or
 
 .. code-block:: console
+    :class: remote-command
 
     $ source ./modules.txt
 
@@ -312,6 +330,7 @@ These modules should be listed first when you use the ``module avail``
 command:
 
 .. code-block:: console
+    :class: remote-command
 
     ---------------- /projects/cbmr_shared/apps/modules/modulefiles ----------------
     add_dbsnp_ids/20231206_1  msconvert/20250218_1    sacct-usage/20240603_1
@@ -327,6 +346,7 @@ Should the modules not be listed, then you can manually register them
 using the ``module use`` command:
 
 .. code-block:: console
+    :class: remote-command
 
     $ module use --prepend /projects/cbmr_shared/apps/modules/modulefiles/
 

--- a/esrum/source/tips/modules.rst
+++ b/esrum/source/tips/modules.rst
@@ -40,6 +40,7 @@ the module files. This organization is designed to simplify maintenance.
 1. Create a subfolder in the ``apps`` for your modules:
 
    .. code-block:: console
+       :class: remote-command
 
        $ mkdir -p /projects/my-project/apps/modules
 
@@ -47,6 +48,7 @@ the module files. This organization is designed to simplify maintenance.
    which we can build our own copy of ``seqtk``:
 
    .. code-block:: console
+       :class: remote-command
 
        $ mkdir -p /projects/my-project/apps/modules/modulefiles/seqtk
        $ mkdir -p /projects/my-project/apps/modules/software/seqtk/1.4
@@ -70,6 +72,7 @@ the module files. This organization is designed to simplify maintenance.
 4. Next download and compile ``seqtk 1.4``:
 
    .. code-block:: console
+       :class: remote-command
 
        $ cd /projects/my-project/apps/modules/software/seqtk/1.4
        $ wget "https://github.com/lh3/seqtk/archive/refs/tags/v1.4.tar.gz"
@@ -81,6 +84,7 @@ the module files. This organization is designed to simplify maintenance.
 5. Place a symlink to the executable in a separate ``bin`` folder:
 
    .. code-block:: console
+       :class: remote-command
 
        $ cd /projects/my-project/apps/modules/software/seqtk/1.4
        $ mkdir bin
@@ -100,6 +104,7 @@ the module files. This organization is designed to simplify maintenance.
    that you can load your modules:
 
    .. code-block:: console
+       :class: remote-command
 
        $ module use --prepend /projects/my-project/apps/modules/modulefiles/
        $ module avail
@@ -142,6 +147,7 @@ that is often built to install it directly in the target directory. An
 example might look like the following:
 
 .. code-block:: console
+    :class: generic-command
 
     $ tar xvzf my-software-1.23.tar.gz
     $ cd my-software-1.23
@@ -161,6 +167,7 @@ typically be accomplished as follows (using VisiData_ as an example):
 1. Basic setup
 
    .. code-block:: console
+       :class: remote-command
 
        $ mkdir -p /projects/my-project/apps/modules/software/visidata/2.11
        $ cd /projects/my-project/apps/modules/software/visidata/2.11
@@ -168,24 +175,28 @@ typically be accomplished as follows (using VisiData_ as an example):
 2. Load the required version of Python (if any)
 
    .. code-block:: console
+       :class: remote-command
 
        $ module load python/3.9.16
 
 3. Create a virtual environment in `./venv` to contain our software
 
    .. code-block:: console
+       :class: remote-command
 
        $ python3 -m venv ./venv
 
 4. Install our desired software
 
    .. code-block:: console
+       :class: remote-command
 
        $ ./venv/bin/pip install visidata
 
 5. Create a bin folder as described above
 
    .. code-block:: console
+       :class: remote-command
 
        $ mkdir bin
        $ ln -s ../venv/bin/visidata bin/

--- a/esrum/source/tips/ports.rst
+++ b/esrum/source/tips/ports.rst
@@ -128,6 +128,7 @@ which you want to forward a port, and replacing ``abc123`` with your
 UCPH short username:
 
 .. code-block:: console
+    :class: local-command
 
     $ ssh -S none -N -L 'XXXXX:esrumcmpn07fl:XXXXX' abc123@esrumhead01fl.unicph.domain
     abc123@esrumhead01fl.unicph.domain's password: ****************
@@ -147,6 +148,7 @@ If the service you wish to connect to is instead running on the head
 node, then use the following command:
 
 .. code-block:: console
+    :class: local-command
 
     $ ssh -S none -N -L 'XXXXX:localhost:XXXXX' abc123@esrumhead01fl.unicph.domain
     abc123@esrumhead01fl.unicph.domain's password: ****************

--- a/esrum/source/tips/r.rst
+++ b/esrum/source/tips/r.rst
@@ -29,6 +29,7 @@ By default, the 4.3.x versions of R loads ``gcc/8.5.0``, so you can
 simply use the ``--auto`` option when loading ``R/4.3.x``:
 
 .. code-block:: console
+    :class: remote-command
 
     $ module load --auto R/4.3.3
     Loading R/4.3.3
@@ -64,6 +65,7 @@ To run an R script on the command-line, simply use the ``Rscript``
 command:
 
 .. code-block:: console
+    :class: generic-command
 
     $ cat my_script.R
     cat("Hello, world!\n")
@@ -74,7 +76,7 @@ For simple scripts you can use the ``commandArgs`` function to pass
 arguments to your scripts, allowing you to use them to process arbitrary
 data-sets:
 
-.. code-block:: R
+.. code-block:: r
     :linenos:
 
     args <- commandArgs(trailingOnly = TRUE)
@@ -82,6 +84,7 @@ data-sets:
     cat("Hello, ", args[1], "!\n", sep="")
 
 .. code-block:: console
+    :class: generic-command
 
     $ Rscript my_script.R world
     Hello, world!
@@ -102,6 +105,7 @@ This allows you to document your command-line options, specify default
 values, and much more:
 
 .. code-block:: console
+    :class: generic-command
 
     $ Rscript my_script.R
     usage: my_script.R [--] [--help] [--opts OPTS] [--p-value P-VALUE]
@@ -142,6 +146,7 @@ The ``"${@}"`` safely passes all your command-line arguments to
 be used to submit/call any of your R-scripts:
 
 .. code-block:: console
+    :class: remote-command
 
     $ sbatch run_rscript.sh my_script.R my_data.tsv --p-value 0.01
     Submitted batch job 18090212
@@ -159,6 +164,7 @@ Modules may be installed in your home folder using the
 ``install.packages`` command:
 
 .. code-block:: console
+    :class: remote-command
 
     $ module load gcc/8.5.0 R/4.3.1
     $ R
@@ -197,9 +203,10 @@ following command to your ``~/.Rprofile`` file:
 
 This can be done by running the following command in your (bash) shell:
 
-.. code-block:: bash
+.. code-block:: console
+    :class: remote-command
 
-    echo -e '\noptions(repos=c(CRAN="https://cloud.r-project.org/"))' | tee -a ~/.Rprofile
+    $ echo -e '\noptions(repos=c(CRAN="https://cloud.r-project.org/"))' | tee -a ~/.Rprofile
 
 Note that this does not affect already running R shells.
 
@@ -213,7 +220,8 @@ one thread by setting the ``MAKEFLAGS`` environment variable.
 
 For example, to install the ``ape`` package:
 
-.. code-block:: shell
+.. code-block:: console
+    :class: remote-command
 
     $ srun --pty -c 8 -- bash
     $ export MAKEFLAGS="-j${SLURM_CPUS_PER_TASK}"
@@ -250,7 +258,8 @@ to using more CPUs to build each package.
 To enable this option by default, append it to your ``~/.Rprofile``
 file. This can be done by running the following command in bash:
 
-.. code-block:: bash
+.. code-block:: console
+    :class: remote-command
 
     echo 'options(Ncpus=2)' | tee -a ~/.Rprofile
 

--- a/esrum/source/tips/r_troubleshooting.rst
+++ b/esrum/source/tips/r_troubleshooting.rst
@@ -22,11 +22,11 @@ running the ``install.packages``:
       libtk8.6.so: cannot open shared object file: No such file or directory
 
 If so, then you must disable graphical menus before running
-``install.packages`` by first entering the following command:
+``install.packages`` by first entering the following command in R:
 
-.. code-block:: console
+.. code-block:: r
 
-    > options(menu.graphics=FALSE)
+    options(menu.graphics=FALSE)
 
 Then simply run ``install.packages`` again.
 
@@ -34,6 +34,7 @@ You can also set the R option permanently by running the following in
 your (bash) terminal:
 
 .. code-block:: console
+    :class: remote-command
 
     $ echo 'options(menu.graphics=FALSE)' | tee -a ~/.Rprofile
 
@@ -54,6 +55,7 @@ before installing the library. For example, to install the ``xml2``
 library:
 
 .. code-block:: console
+    :class: remote-command
 
     (my-env) $ conda deactivate
     (base) $ conda deactivate
@@ -69,6 +71,7 @@ load on the RStudio node or when ``gcc/8.5.0`` is loaded on the
 head/compute nodes:
 
 .. code-block:: console
+    :class: remote-command
 
     $ R
     > library(wk)
@@ -81,11 +84,11 @@ one of two methods:
 
 1. Connect to the RStudio server as described in the
    :ref:`s_service_rstudio` section, and simply install the affected
-   packages using the ``install.packages`` function:
+   packages using the ``install.packages`` function in R:
 
-   .. code-block:: console
+   .. code-block:: r
 
-       > install.packages("wk")
+       install.packages("wk")
 
    You may need to repeat this step multiple times, for every package
    that fails to load.
@@ -94,6 +97,7 @@ one of two methods:
    correct version of GCC before loading R:
 
    .. code-block:: console
+       :class: remote-command
 
        $ module load gcc/8.5.0 R/4.3.2
        $ R
@@ -110,18 +114,21 @@ You can identify all affected packages in your "global" R library by
 running the following commands:
 
 .. code-block:: console
+    :class: remote-command
 
     $ module load gcc/8.5.0 R/4.3.2
 
 1. ``cd`` to your R library
 
    .. code-block:: console
+       :class: remote-command
 
        $ cd ~/R/x86_64-pc-linux-gnu-library/4.3/
 
 2. Test every installed library
 
    .. code-block:: console
+       :class: remote-command
 
        $ for lib in $(ls);do echo "Testing ${lib}"; Rscript <(echo "library(${lib})") > /dev/null;done
 
@@ -147,6 +154,7 @@ Locate the error messages like the one shown above in the output and
 reinstall the affected libraries using the ``install.packages`` command:
 
 .. code-block:: console
+    :class: remote-command
 
     $ R
     > install.packages(c("igraph", "isoband"))

--- a/esrum/source/tips/robust_scripts.rst
+++ b/esrum/source/tips/robust_scripts.rst
@@ -39,6 +39,7 @@ programming languages, it is not an error to access a variable that does
 not exist:
 
 .. code-block:: console
+    :class: generic-command
 
     $ cat myscript.sh
     #!/bin/bash
@@ -58,6 +59,7 @@ most of the time this is a mistake. To prevent this, you can set the
 ``nounset`` option, which causes bash to terminate on unset variables:
 
 .. code-block:: console
+    :class: generic-command
 
     $ cat myscript.sh
     #!/bin/bash
@@ -100,6 +102,7 @@ partially or wholly corrupt data:
 This produces the following output:
 
 .. code-block:: console
+    :class: generic-command
 
     $ ls
     my-sketch.sh
@@ -169,6 +172,7 @@ To mitigate these problems, we can make use of the following options:
 Running this script produces the following, helpful output:
 
 .. code-block:: console
+    :class: generic-command
 
     $ ls
     my-sketch.sh
@@ -273,6 +277,7 @@ to delete when the script is done running:
 Running the script looks like this:
 
 .. code-block:: console
+    :class: generic-command
 
     $ bash example.sh
     Do something with '/tmp/tmp.BaH9GKP50J' here!
@@ -295,6 +300,7 @@ For example, if we run shell check on the very first script shown on
 this page:
 
 .. code-block:: console
+    :class: remote-command
 
     $ module load shellcheck
     $ shellcheck myscript.sh
@@ -319,6 +325,7 @@ the ``trap`` command above but which prints less information about the
 failure:
 
 .. code-block:: console
+    :class: generic-command
 
     $ snakemake
     sed: -e expression #1, char 16: unterminated `s' command

--- a/esrum/source/tips/snakemake.rst
+++ b/esrum/source/tips/snakemake.rst
@@ -48,6 +48,7 @@ Snakemake that you use. You can check this via ``snakemake --version``,
 if you are unsure:
 
 .. code-block:: console
+    :class: generic-command
 
     $ snakemake --version
     9.6.0
@@ -76,6 +77,7 @@ options ``--slurm`` and ``--jobs N``, where the ``N`` is the maximum
 number of jobs you want to queue simultaneously. For example,
 
 .. code-block:: console
+    :class: remote-command
 
     $ module load snakemake/7.30.1
     $ snakemake --slurm --jobs 32
@@ -96,6 +98,7 @@ where the ``N`` is the maximum number of jobs you want to queue
 simultaneously. For example,
 
 .. code-block:: console
+    :class: remote-command
 
     $ module load snakemake/9.9.0
     $ snakemake --executor slurm --default-resources --jobs 32
@@ -119,7 +122,7 @@ Requesting CPUs
 Snakemake will automatically request a number of CPUs corresponding to
 the number of threads used by a rule:
 
-.. code-block::
+.. code-block:: text
     :linenos:
 
     rule my_rule:
@@ -143,6 +146,7 @@ CPU reserved, and we therefore recommend overriding this default using
 the ``--default-resources`` option:
 
 .. code-block:: console
+    :class: generic-command
 
     $ snakemake --default-resources mem_mb_per_cpu=15948
 
@@ -152,7 +156,7 @@ Should a job require more memory than the default ~16 GB per CPU, then
 you can request additional memory using the ``resources`` section of
 your rule:
 
-.. code-block::
+.. code-block:: text
     :linenos:
 
     rule my_rule:
@@ -173,7 +177,7 @@ specifying that you want to use the ``gpuqueue`` by adding
 rule. Once you have done so, you can reserve GPUs using the
 ``slurm_extra`` resource:
 
-.. code-block::
+.. code-block:: text
     :linenos:
 
     rule gpu_example:
@@ -190,7 +194,7 @@ If you need memory rather than GPUs, then omit the ``slurm_extra``
 resource and instead specify the amount of RAM needed in MB, using the
 ``mem_mb`` resource as described above:
 
-.. code-block::
+.. code-block:: text
     :linenos:
 
     rule high_mem_example:
@@ -220,7 +224,7 @@ profile (see below). When that is done, Snakemake will automatically
 load the environment modules listed in the ``envmodules`` section of a
 rule:
 
-.. code-block::
+.. code-block:: text
     :linenos:
 
     rule my_rule:
@@ -298,6 +302,7 @@ in your project folder. Then run Snakemake with the ``--profile`` option
 pointing to the folder in which you saved your profile:
 
 .. code-block:: console
+    :class: generic-command
 
     $ snakemake --profile /path/to/profile/
 
@@ -316,6 +321,7 @@ Version 9 ``/projects/cbmr_shared/apps/config/snakemake/9``
 For example, to use the profile for Snakemake 9:
 
 .. code-block:: console
+    :class: remote-command
 
     $ module load snakemake/9.9.0
     $ snakemake --profile /projects/cbmr_shared/apps/config/snakemake/9
@@ -324,6 +330,7 @@ Options specified in this profile can be overridden on the command-line
 simply by specifying the option again:
 
 .. code-block:: console
+    :class: remote-command
 
     $ snakemake --profile /projects/cbmr_shared/apps/config/snakemake/9 --jobs 16
 

--- a/esrum/source/tips/tmux.rst
+++ b/esrum/source/tips/tmux.rst
@@ -28,6 +28,7 @@ To get started, ``cd`` to the directory you wish to work in and run
 ``tmux`` or the longer (but equivalent) command ``tmux new``:
 
 .. code-block:: console
+    :class: remote-command
 
     $ cd /projects/my_project/people/abc123
     $ tmux
@@ -84,6 +85,7 @@ Once you wish to resume your work, you can use the ``tmux attach``
 command to re-open your running sessions:
 
 .. code-block:: console
+    :class: remote-command
 
     $ tmux attach
 
@@ -96,6 +98,7 @@ Alternatively, you can list your sessions with ``tmux ls`` and attach to
 one of them:
 
 .. code-block:: console
+    :class: remote-command
 
     $ tmux ls
     0: 1 windows (created Thu Apr 10 16:31:43 2025)
@@ -121,6 +124,7 @@ with ``-n`` as follows. However, this can only if you are not already in
 an active tmux session:
 
 .. code-block:: console
+    :class: remote-command
 
     $ tmux new -s project -n task
 

--- a/esrum/source/usage/access/connecting.rst
+++ b/esrum/source/usage/access/connecting.rst
@@ -183,6 +183,7 @@ terminal command ``ssh``, replacing ``abc123`` with your UCPH username
 in the following command:
 
 .. code-block:: console
+    :class: local-command
 
     $ ssh abc123@esrumhead01fl.unicph.domain
 
@@ -193,6 +194,7 @@ continue. Once you've done so, you can enter your UCPH account password,
 and approve the connection via the NetIQ app.
 
 .. code-block:: console
+    :class: local-command
     :emphasize-lines: 5,7
 
     $ ssh abc123@esrumhead01fl.unicph.domain
@@ -224,10 +226,11 @@ and approve the connection via the NetIQ app.
     VPN. This message could mean that you are connecting to an entirely
     different server!
 
-It is recommended to add an entry for the cluster to your
-``.ssh/config`` file, replacing ``abc123`` with your UCPH username:
+It is recommended to add an entry for the cluster to the ``.ssh/config``
+file on your own computer, replacing ``abc123`` with your UCPH username:
 
 .. code-block:: console
+    :class: local-command
 
     $ cat ~/.ssh/config
     Host esrum esrumhead01fl esrumhead01fl.unicph.domain
@@ -239,6 +242,7 @@ This allows you to connect to the server using the names ``esrum``,
 having to specify your username:
 
 .. code-block:: console
+    :class: local-command
 
     $ ssh esrum
     abc123@esrumhead01fl.unicph.domain's password:
@@ -274,6 +278,7 @@ downloaded, open a terminal in the folder in which you downloaded the
 installer, and run the following command:
 
 .. code-block:: console
+    :class: local-command
 
     $ sudo bash cisco-secure-client-linux64-*.sh
 
@@ -287,6 +292,7 @@ username. You will need to enter your password and use the
 authentication method you have configured (here a TOTP code generator):
 
 .. code-block:: console
+    :class: local-command
     :emphasize-lines: 7,10
 
     $ sudo openconnect -u abc123 --useragent=AnyConnect --no-external-auth vpn.ku.dk

--- a/esrum/source/usage/access/connecting_troubleshooting.rst
+++ b/esrum/source/usage/access/connecting_troubleshooting.rst
@@ -24,6 +24,7 @@ You may experience timeout errors when you attempt to connect to Esrum.
 On Linux, this typically results in an ``Operation timed out`` message:
 
 .. code-block:: console
+    :class: local-command
 
     $ ssh abc123@esrumhead01fl.unicph.domain
     ssh: connect to host esrumhead01fl.unicph.domain port 22: Operation timed out
@@ -103,6 +104,7 @@ and your account being ready for use. If you connect to Esrum before
 this, you may see an error regarding your home folder not existing:
 
 .. code-block:: console
+    :class: local-command
 
     $ ssh abc123@esrumhead01fl.unicph.domain
     Could not chdir to home directory /home/abc123: No such file or directory

--- a/esrum/source/usage/services/agents.rst
+++ b/esrum/source/usage/services/agents.rst
@@ -37,6 +37,7 @@ To start using a sandboxed AI Agent, simply load the module and run
 (non-sensitive) files:
 
 .. code-block:: console
+    :class: remote-command
 
     $ cd /home/abc123/my-scripts/
     $ module load agent-container
@@ -80,6 +81,7 @@ All command-line arguments written after the agent name, ``shell``, or
 example, to view the help text for ``claude``, simply run
 
 .. code-block:: console
+    :class: remote-command
 
     $ agent-container claude --help
 
@@ -87,6 +89,7 @@ Arguments for ``agent-container`` itself must go before the agent name.
 For example, to pass the ``--read-only`` option to ``agent-container``:
 
 .. code-block:: console
+    :class: remote-command
 
     $ agent-container --read-only claude
 
@@ -101,6 +104,7 @@ example, to include the directory ``/projects/cbmr_shared/apps`` in
 addition to the current working directory,
 
 .. code-block:: console
+    :class: remote-command
 
     $ cd /home/abc123/my-scripts/
     $ agent-container --include /projects/cbmr_shared/apps claude
@@ -115,6 +119,7 @@ both the current working directory and any folders included via
 ``agent-container``:
 
 .. code-block:: console
+    :class: remote-command
 
     $ agent-container --read-only claude
 
@@ -136,6 +141,7 @@ options:
 For example, to install the Conda package for R, using ``pixi``:
 
 .. code-block:: console
+    :class: remote-command
 
     $ agent-container shell
     (agent-container) $ pixi global install r-base
@@ -145,6 +151,7 @@ For example, to install the Conda package for R, using ``pixi``:
 Or, to install ``ruff`` from PyPi using ``uv``:
 
 .. code-block:: console
+    :class: remote-command
 
     $ agent-container shell
     (agent-container) $ uv tool install ruff

--- a/esrum/source/usage/services/containers.rst
+++ b/esrum/source/usage/services/containers.rst
@@ -40,6 +40,7 @@ For the following example, we will download and run version ``0.7.17``
 of the `pegi3s/bwa`_ image on `Docker Hub`_:
 
 .. code-block:: console
+    :class: remote-command
 
     $ module load --auto singularity
     $ singularity build --disable-cache pegi3s_bwa_0.7.17.sif docker://pegi3s/bwa:0.7.17
@@ -59,6 +60,7 @@ Once you have run the ``build`` command, the image can be run using the
 ``singularity run`` command:
 
 .. code-block:: console
+    :class: remote-command
 
     $ singularity run pegi3s_bwa_0.7.17.sif bwa
 
@@ -70,6 +72,7 @@ It is also possible to run `Docker Hub`_ images "directly" by using a
 ``docker://`` URL instead of the path to a singularity image:
 
 .. code-block:: console
+    :class: remote-command
 
     $ singularity run docker://pegi3s/bwa:0.7.17 bwa
 
@@ -85,6 +88,7 @@ corresponding ``docker save`` command may be used to export an image to
 a single file:
 
 .. code-block:: console
+    :class: local-command
 
     $ podman save my-image:v1.2.3 --output ~/my_image_v1.2.3.tar
 
@@ -92,6 +96,7 @@ Once the image has been exported, you can transfer it to Esrum using
 ``scp`` or another such method:
 
 .. code-block:: console
+    :class: local-command
 
     $ scp ~/my_image_v1.2.3.tar abc123@esrumhead01fl.unicph.domain:/projects/my_project/scratch/
 
@@ -99,6 +104,7 @@ Finally, you can convert the image on Esrum to the format used by
 singularity:
 
 .. code-block:: console
+    :class: local-command
 
     $ ssh abc123@esrumhead01fl.unicph.domain
     $ module load --auto singularity
@@ -109,6 +115,7 @@ The singularity image can then be run using the ``singularity run``
 command:
 
 .. code-block:: console
+    :class: remote-command
 
     $ singularity run --bind /maps,/projects,/datasets,/scratch my_image_v1.2.3.sif
 

--- a/esrum/source/usage/services/jupyter.rst
+++ b/esrum/source/usage/services/jupyter.rst
@@ -26,6 +26,7 @@ add support for R.
 To start a notebook on a node, run the following commands:
 
 .. code-block:: console
+    :class: remote-command
 
     $ module load jupyter-notebook
     $ srun --pty -- jupyter notebook --no-browser --ip=0.0.0.0 --port=XXXXX
@@ -126,6 +127,7 @@ job is running. This can be done in a couple of ways:
   separate terminal:
 
   .. code-block:: console
+      :class: remote-command
 
       $ squeue --me --name jupyter
       JOBID  PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
@@ -157,6 +159,7 @@ Python environment:
    self-contained:
 
    .. code-block:: console
+       :class: remote-command
 
        # to deactivate Conda environments:
        conda deactivate
@@ -166,6 +169,7 @@ Python environment:
 2. Load the Python version you wish to use, for example 3.11.3:
 
    .. code-block:: console
+       :class: remote-command
 
        module load python/3.11.3
 
@@ -174,6 +178,7 @@ Python environment:
    that you prefer:
 
    .. code-block:: console
+       :class: remote-command
 
        python3 -m venv my_jupyter
 
@@ -184,6 +189,7 @@ Python environment:
    Notebook:
 
    .. code-block:: console
+       :class: remote-command
 
        ./my_jupyter/bin/pip install notebook # the latest version, or
        ./my_jupyter/bin/pip install notebook==7.4.5 # a specific version
@@ -192,6 +198,7 @@ Python environment:
    ``pandas``:
 
    .. code-block:: console
+       :class: remote-command
 
        ./my_jupyter/bin/pip install pandas
 
@@ -199,6 +206,7 @@ To start the notebook, run the following command, replacing ``XYZ`` with
 the port number you are using (see above for more information)
 
 .. code-block:: console
+    :class: remote-command
 
     srun --pty -- ./my_jupyter/bin/jupyter notebook --no-browser --ip=0.0.0.0 --port=XYZ
 
@@ -219,6 +227,7 @@ To do so, run the following commands, replacing `R/4.3.3` with the
 version of R that you wish to use:
 
 .. code-block:: console
+    :class: remote-command
 
     $ module load jupyter-notebook/6.5.4
     $ module load --auto R/4.3.3
@@ -238,6 +247,7 @@ of R and ``gcc`` that R depends on.
 Once you are done adding R versions, you start notebook as shown above:
 
 .. code-block:: console
+    :class: remote-command
 
     $ module load jupyter-notebook/6.5.4
     $ srun --pty -- jupyter notebook --no-browser --port=XXXXX
@@ -247,6 +257,7 @@ run R code, you must do so if you wish to install R libraries via the
 notebook:
 
 .. code-block:: console
+    :class: remote-command
 
     $ module load jupyter-notebook/6.5.4
     $ module load --auto R/4.3.3
@@ -281,6 +292,7 @@ Notebook:
 2. Install `jupyter_slurm` in the environment
 
    .. code-block:: console
+       :class: remote-command
 
        # install the latest version of the module
        ./my_jupyter/bin/pip install /projects/cbmr_shared/apps/dap/jupyter_slurm/latest
@@ -291,6 +303,7 @@ To start the notebook, run, replacing ``XYZ`` with the port number you
 are using (see above for more information)
 
 .. code-block:: console
+    :class: remote-command
 
     srun --pty -- ./my_jupyter/bin/jupyter notebook --no-browser --ip=0.0.0.0 --port=XYZ
 

--- a/esrum/source/usage/services/shiny.rst
+++ b/esrum/source/usage/services/shiny.rst
@@ -36,6 +36,7 @@ cannot access the ``ndir`` folder, then please see the
 It is strongly recommended that you create a folder with your username:
 
 .. code-block:: console
+    :class: remote-command
 
     $ mkdir -p ~/ucph/ndir/SUN-CBMR-shinyapp/$USER
 
@@ -44,7 +45,7 @@ home folder named ``shiny``. To verify that everything is working
 correctly, create a file name ``app.R`` in
 ``~/ucph/ndir/SUN-CBMR-shinyapp/$USER`` with the following content:
 
-.. code-block:: R
+.. code-block:: r
     :linenos:
 
     library(shiny)

--- a/esrum/source/usage/slurm/advanced.rst
+++ b/esrum/source/usage/slurm/advanced.rst
@@ -33,6 +33,7 @@ that there is plenty capacity for whatever temporary files your programs
 might generate:
 
 .. code-block:: bash
+    :class: remote-command
     :linenos:
 
     #!/bin/bash
@@ -58,6 +59,7 @@ command without Slurm. Simply prefix your command with ``srun`` and the
 queuing system takes care of running it on the first available node:
 
 .. code-block:: console
+    :class: remote-command
 
     $ srun gzip chr20.fasta
 
@@ -70,6 +72,7 @@ to a file or to another command, then you *must* wrap your commands in a
 bash (or similar) script:
 
 .. code-block:: console
+    :class: remote-command
 
     $ srun bash my_script.sh
 
@@ -86,6 +89,7 @@ To cancel a job running with srun, simply press `Ctrl + c` twice within
 1 second:
 
 .. code-block:: console
+    :class: remote-command
 
     $ srun gzip chr20.fasta
     <ctrl+c> srun: interrupt (one more within 1 sec to abort)
@@ -148,6 +152,7 @@ task IDs.
 Our script can then be run as before:
 
 .. code-block:: console
+    :class: remote-command
 
     $ ls
     chr1.fasta chr2.fasta chr3.fasta chr4.fasta chr5.fasta my_script.sh
@@ -205,6 +210,7 @@ using ``scontrol``. The following updates the job array with ID
 ``12345`` and sets its maximum number of simultaneous jobs to 32:
 
 .. code-block:: console
+    :class: remote-command
 
     $ scontrol update JobId=12345 ArrayTaskThrottle=32
 
@@ -220,6 +226,7 @@ entire job (all tasks in the array) simply use the primary job ID before
 the underscore/dot:
 
 .. code-block:: console
+    :class: remote-command
 
     $ scancel 8504
 
@@ -228,6 +235,7 @@ sub-task after the ID of the batch job, using a dot (``.``) to separate
 the two IDs instead of an underscore (``_``):
 
 .. code-block:: console
+    :class: remote-command
 
     $ scancel 8504.1
 

--- a/esrum/source/usage/slurm/basics.rst
+++ b/esrum/source/usage/slurm/basics.rst
@@ -102,6 +102,7 @@ To queue this script, run the ``sbatch`` command with the filename of
 the script as an argument:
 
 .. code-block:: console
+    :class: remote-command
 
     $ ls
     chr1.fasta  my_script.sh
@@ -131,6 +132,7 @@ where ``${JOBID}`` is the ID reported by ``sbatch``, ``8503`` in this
 example:
 
 .. code-block:: console
+    :class: remote-command
 
     $ ls
     chr1.fasta  chr1.fasta.gz  my_script.sh  slurm-8503.out
@@ -142,6 +144,7 @@ misspelled the filename in our command then the resulting error message
 would be found in the ``out`` file:
 
 .. code-block:: console
+    :class: remote-command
 
     $ cat slurm-8503.out
     igzip: chr1.fast does not exist
@@ -167,6 +170,7 @@ We can then invoke the script using ``sbatch`` as above, specifying the
 name of the file we wanted to compress on the command-line:
 
 .. code-block:: console
+    :class: remote-command
 
     $ sbatch my_script.sh "chr1.fasta"
 
@@ -188,6 +192,7 @@ You can check the status of your queued and running jobs using the
 jobs are shown, rather than everyone's jobs:
 
 .. code-block:: console
+    :class: remote-command
 
     $ squeue --me
     JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
@@ -200,6 +205,7 @@ Completed jobs are removed from the ``squeue`` list and can instead be
 listed using ``sacct``:
 
 .. code-block:: console
+    :class: remote-command
 
     $ sacct
            JobID    JobName  Partition    Account  AllocCPUS      State ExitCode
@@ -220,6 +226,7 @@ Already running jobs can be cancelled using the ``scancel`` command and
 the ID of the job you want to cancel:
 
 .. code-block:: console
+    :class: remote-command
 
     $ squeue --me
     JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
@@ -229,6 +236,7 @@ the ID of the job you want to cancel:
 Should you wish to cancel *all* your jobs, use the ``-u`` option:
 
 .. code-block:: console
+    :class: remote-command
 
     $ scancel -u ${USER}
 
@@ -256,6 +264,7 @@ like, is to use ``#SBATCH`` comments.
 For example, instead of queuing our job with the command
 
 .. code-block:: console
+    :class: remote-command
 
     $ sbatch --my-option my_script.sh
 
@@ -464,6 +473,7 @@ not mentioned above. All of these options may be specified using
   before queuing your job:
 
   .. code-block:: console
+      :class: remote-command
 
       $ sbatch --test-only --verbose my_script.sh
       sbatch: defined options
@@ -493,6 +503,7 @@ need to experiment with running a computationally heavy process, then
 you can start a shell on one of the compute nodes as follows:
 
 .. code-block:: console
+    :class: remote-command
 
     [abc123@esrumhead01fl ~] $ srun --pty -- /bin/bash
     [abc123@esrumcmpn07fl ~] $
@@ -511,6 +522,7 @@ used for reserving additional resources if you need more than the
 default 2 CPUs and 31 GB of RAM:
 
 .. code-block:: console
+    :class: remote-command
 
     $ srun --cpus-per-task 4 --mem 128G --pty -- /bin/bash
 
@@ -539,6 +551,7 @@ cluster.
   option when connecting to the server:
 
   .. code-block:: console
+      :class: local-command
 
       $ ssh -X esrumhead01fl
 
@@ -556,6 +569,7 @@ Once you have connected to Esrum with X11 forwarding enabled, you must
 start an interactive session with the ``--x11`` option:
 
 .. code-block:: console
+    :class: remote-command
 
     $ srun --pty --x11 -- /bin/bash
     $ xclock

--- a/esrum/source/usage/slurm/basics_troubleshooting.rst
+++ b/esrum/source/usage/slurm/basics_troubleshooting.rst
@@ -28,6 +28,7 @@ Slurm will report that the request cannot be satisfied.
 If more than 128 CPUs requested:
 
 .. code-block:: console
+    :class: remote-command
 
     $ sbatch --cpus-per-task 200 my_script.sh
     sbatch: error: CPU count per node can not be satisfied
@@ -36,6 +37,7 @@ If more than 128 CPUs requested:
 More than 1993 GB RAM requested on compute node:
 
 .. code-block:: console
+    :class: remote-command
 
     $ sbatch --mem 2000G my_script.sh
     sbatch: error: Memory specification can not be satisfied
@@ -52,6 +54,7 @@ specifying the correct queue or if you request too many GPUs.
 If ``--partition=gpuqueue`` not specified:
 
 .. code-block:: console
+    :class: remote-command
 
     $ srun --gres=gpu:2 -- echo "Hello world!"
     srun: error: Unable to allocate resources: Requested node configuration is not available
@@ -59,6 +62,7 @@ If ``--partition=gpuqueue`` not specified:
 If more than 2 GPUs requested:
 
 .. code-block:: console
+    :class: remote-command
 
     $ srun --partition=gpuqueue --gres=gpu:3 -- echo "Hello world!"
     srun: error: Unable to allocate resources: Requested node configuration is not available
@@ -76,7 +80,8 @@ that a ``slurm_bcast_*`` executable in that folder could not be found,
 where the executable name contains the job ID and the node on which it
 was run:
 
-.. code-block::
+.. code-block:: console
+    :class: remote-command
 
     $ srun --pty /bin/
     slurmstepd: error: execve(): /bin/slurm_bcast_123456.0_esrumcmpn01fl: No such file or directory
@@ -84,7 +89,8 @@ was run:
 
 To fix this, ensure that you are running an executable and not a folder:
 
-.. code-block::
+.. code-block:: console
+    :class: remote-command
 
     $ srun --pty /bin/bash
 

--- a/esrum/source/usage/slurm/gpu.rst
+++ b/esrum/source/usage/slurm/gpu.rst
@@ -58,6 +58,7 @@ node:
 This script can then be submitted as usual:
 
 .. code-block:: console
+    :class: remote-command
 
     $ sbatch my_hi_mem_job.sh
     Submitted batch job 217217
@@ -97,6 +98,7 @@ reserve 1 GPU per job, which is normally also more efficient.
 This script can then be submitted as usual:
 
 .. code-block:: console
+    :class: remote-command
 
     $ sbatch my_gpu_job.sh
     Submitted batch job 217218
@@ -126,6 +128,7 @@ To request an A100 GPU, replace the ``--gres=gpu:1`` option with
 This script can then be submitted as usual:
 
 .. code-block:: console
+    :class: remote-command
 
     $ sbatch my_h100_job.sh
     Submitted batch job 217219
@@ -153,6 +156,7 @@ you need a GPU, as well as other resource options described in the
 :ref:`reserving_resources` section:
 
 .. code-block:: console
+    :class: remote-command
 
     $ srun --pty --partition=gpuqueue -- /bin/bash
     # or, also reserving a GPU

--- a/esrum/source/usage/slurm/monitoring.rst
+++ b/esrum/source/usage/slurm/monitoring.rst
@@ -25,6 +25,7 @@ finish, fail, are re-queued, or some combination. This is accomplished
 by using the ``--mail-user`` and ``--mail-type`` options:
 
 .. code-block:: console
+    :class: remote-command
 
     $ sbatch --mail-user=abc123@ku.dk --mail-type=END,FAIL my_script.sh
     Submitted batch job 8503
@@ -42,6 +43,7 @@ These options can naturally also be embedded in your sbatch script:
 and queued as usual:
 
 .. code-block:: console
+    :class: remote-command
 
     $ sbatch my-script.sh
     Submitted batch job 8504
@@ -84,6 +86,7 @@ for that reason we provide a helper script, sacct-usage_, that
 summarizes some of this information in a more easily readable form.
 
 .. code-block:: console
+    :class: remote-command
 
     $ sacct-usage
     User    Job   Start                   Elapsed  State      CPUsReserved  CPUsUsed  MemReserved  MemUsed  Name
@@ -126,6 +129,7 @@ this example, where we wish to measure the resource usage of the
 ``my-command`` program:
 
 .. code-block:: console
+    :class: generic-command
 
     $ /usr/bin/time -f "CPU = %P, MEM = %M" my-command --threads 1 ...
     CPU = 99%, MEM = 840563KB
@@ -167,6 +171,7 @@ using for example the ``squeue --me`` command (from the ``JOBID``
 column), as shown here:
 
 .. code-block:: console
+    :class: remote-command
 
     $ squeue --me
     JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
@@ -205,6 +210,7 @@ If you are running a job in an :ref:`interactive session
 directly using the ``nvidia-smi`` command:
 
 .. code-block:: console
+    :class: remote-command
 
     $ nvidia-smi -l 5
     Thu Apr  4 14:30:46 2024
@@ -252,6 +258,7 @@ To watch the content of this log-file, firstly determine the job ID of
 your job running on the GPU node:
 
 .. code-block:: console
+    :class: remote-command
 
     $ squeue --me --partition=gpuqueue
      JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
@@ -263,6 +270,7 @@ The ``--gres=none`` option is required, since otherwise Slurm would try
 to reserve the GPU our job already uses and eventually time out.
 
 .. code-block:: console
+    :class: remote-command
 
     $ srun --overlap --jobid 570316 --gres=none --pty -- watch -n 15 -d cat /scratch/gpus/nvidia-smi.txt
 
@@ -291,6 +299,7 @@ cluster, for example to decide how many resources you can reasonably use
 for a job (see :ref:`s_best_practice_resources`):
 
 .. code-block:: console
+    :class: remote-command
 
     $ module load slurmboard
     $ slurmboard

--- a/esrum/source/usage/slurm/monitoring_troubleshooting.rst
+++ b/esrum/source/usage/slurm/monitoring_troubleshooting.rst
@@ -12,7 +12,7 @@
 If you attempt to run ``sacct`` or ``sacct-usage`` on any other node
 than the head node, then you may get an error message like this:
 
-.. code-block:: console
+.. code-block:: text
 
     sacct: error: slurm_persist_conn_open_without_init: failed to open persistent connection to host:localhost:6819: Connection refused
     sacct: error: Sending PersistInit msg: Connection refused

--- a/esrum/source/usage/storage/best_practice.rst
+++ b/esrum/source/usage/storage/best_practice.rst
@@ -41,6 +41,7 @@ use, and thereby storage costs:
   a step to your workflow that deletes the ``intermediate.dat`` file:
 
   .. code-block:: console
+      :class: generic-command
 
       $ program1 input.dat > intermediate.dat
       $ program2 intermediate.dat > final.results
@@ -56,6 +57,7 @@ use, and thereby storage costs:
   we do not want to keep it):
 
   .. code-block:: console
+      :class: generic-command
 
       $ mkdir results temp
       $ program1 input/input.dat > temp/intermediate.dat
@@ -75,6 +77,7 @@ use, and thereby storage costs:
   reading compressed data:
 
   .. code-block:: console
+      :class: generic-command
 
       # 1. Pipe decompressed data to STDIN
       $ zcat my-data.dat.gz | my-program
@@ -118,6 +121,7 @@ storage:
   ``/datasets/cbmr_shared`` folder,
 
   .. code-block:: console
+      :class: remote-command
 
       $ cd /datasets/cbmr_shared
       $ ncdu
@@ -129,6 +133,7 @@ storage:
   mainly useful if you want to look at a subset of folders:
 
   .. code-block:: console
+      :class: remote-command
 
       $ cd /datasets/cbmr_shared/resources
       $ du -chs * | sort -rh
@@ -145,6 +150,7 @@ storage:
 - The ``find`` command can be used to find files over a certain size:
 
   .. code-block:: console
+      :class: remote-command
 
       $ cd /datasets/cbmr_shared
       $ find . -type f -size +10G
@@ -178,6 +184,7 @@ Esrum. For example, to check for compressible files in
 ``/datasets/cbmr_shared``:
 
 .. code-block:: console
+    :class: remote-command
 
     $ srun --pty -- bash
     $ cd /datasets/cbmr_shared
@@ -209,6 +216,7 @@ example,
 - ``*.sam`` files should be converted to BAM format using samtools_:
 
   .. code-block:: console
+      :class: remote-command
 
       $ module load --auto samtools
       $ samtools view -b input.sam > output.bam
@@ -223,6 +231,7 @@ example,
   indexed using tabix_:
 
   .. code-block:: console
+      :class: remote-command
 
       $ module load --auto htslib
       $ bgzip input.vcf
@@ -231,6 +240,7 @@ example,
   pigz_ to compress the data in a ``gzip`` compatible format:
 
   .. code-block:: console
+      :class: remote-command
 
       $ pigz input.dat
 
@@ -243,6 +253,7 @@ example,
     option for the tool you are using:
 
     .. code-block:: console
+        :class: remote-command
 
         $ srun --pty -c 4 -- bash # reserve 4 CPUs
         $ samtools view -b -@ 4 input.sam > output.bam

--- a/esrum/source/usage/storage/index.rst
+++ b/esrum/source/usage/storage/index.rst
@@ -115,6 +115,7 @@ on how to apply for access to projects.
 Projects on Esrum are located in the ``/projects`` folder:
 
 .. code-block:: console
+    :class: remote-command
 
     $ ls -1 /projects
     phenomics-AUDIT
@@ -263,6 +264,7 @@ folder, even you use ``ls -a``, but they can be accessed like any other
 folder:
 
 .. code-block:: console
+    :class: remote-command
 
     $ cd /projects/cbmr_shared/data/.snapshot
     $ ls
@@ -284,7 +286,8 @@ for such projects.
     Please contact UCPH-IT should you need to restore a large amount of
     deleted data.
 
-.. code-block::
+.. code-block:: console
+    :class: remote-command
 
     $ srun -c 4 pigz -c 4 /projects/my-project/qctool/chr_4_qctool_filtered.gen
 

--- a/esrum/source/usage/storage/networkdrives.rst
+++ b/esrum/source/usage/storage/networkdrives.rst
@@ -78,6 +78,7 @@ The variable ``${USER}`` refers to *your* username, in the form
 actually try to access them, for example via ``ls`` or ``cd``:
 
 .. code-block:: console
+    :class: remote-command
 
     $ /usr/bin/kinit
     abc123@UNICPH.DOMAIN's password: ************
@@ -109,6 +110,7 @@ To (re-)authenticate and thereby enable access to the network drives,
 run ``/usr/bin/kinit`` and enter the password for your UCPH account:
 
 .. code-block:: console
+    :class: remote-command
 
     $ /usr/bin/kinit
     abc123@UNICPH.DOMAIN's password: ************
@@ -151,6 +153,7 @@ The maximum duration of your current session (Kerberos ticket) is about
 ``/usr/bin/klist``:
 
 .. code-block:: console
+    :class: remote-command
 
     $ /usr/bin/klist
     Ticket cache: KEYRING:persistent:436828696:krb_ccache_nBciOlx
@@ -169,6 +172,7 @@ basic ``/usr/bin/kinit`` command, this does not require that you enter
 your password:
 
 .. code-block:: console
+    :class: remote-command
 
     $ /usr/bin/kinit -R
     $ /usr/bin/klist

--- a/esrum/source/usage/storage/networkdrives_troubleshooting.rst
+++ b/esrum/source/usage/storage/networkdrives_troubleshooting.rst
@@ -25,6 +25,7 @@ folder(s) are still missing, then run the following command to create
 any missing network folders:
 
 .. code-block:: console
+    :class: remote-command
 
     $ bash /etc/profile.d/symlink-ucphmaps.sh
 
@@ -53,6 +54,7 @@ access has timed out.
 The ``kinit`` command may fail if you are using a ``conda`` environment:
 
 .. code-block:: console
+    :class: remote-command
 
     (base) $ kinit
     kinit: Unknown credential cache type while getting default ccache

--- a/esrum/source/usage/transfers/external.rst
+++ b/esrum/source/usage/transfers/external.rst
@@ -98,6 +98,7 @@ connecting to ``sftp.ku.dk``, depending on how you have configured `UCPH
 two-factor authentication`_.
 
 .. code-block:: console
+    :class: local-command
 
     $ rsync -av my-data/ abc123@sftp.ku.dk:/projects/my-project-AUDIT/data/my-data/
     (abc123@sftp.ku.dk) Enter password
@@ -129,6 +130,7 @@ Computerome documentation`_.
 For example, to transfer data from Esrum to Computerome, you might run
 
 .. code-block:: console
+    :class: remote-command
 
     $ srun rsync -av ./ ${USERNAME}@transfer.computerome.dk:/home/projects/ab_12345/people/${USERNAME}/
 

--- a/esrum/source/usage/transfers/internal.rst
+++ b/esrum/source/usage/transfers/internal.rst
@@ -30,12 +30,14 @@ command on a compute node, as shown in the examples below. See the
 1. If you are copying data from a ``/projects`` folder, use the command
 
    .. code-block:: console
+       :class: remote-command
 
        srun rsync -av --progress /copy/this/data/ /to/this/location/
 
 2. If you are copying data from a ``/datasets`` folder, use the command
 
    .. code-block:: console
+       :class: remote-command
 
        srun rsync -av --no-group --chmod=ugo=rwX --progress /copy/this/data/
        /to/this/location/
@@ -75,7 +77,8 @@ an interactive session, and *then* log in using the ``/usr/bin/kinit``
 command. Once you have done this, you should be able to access the
 network drives via the ``/maps`` folder:
 
-.. code-block:: bash
+.. code-block:: console
+    :class: remote-command
 
     # 1. Start an interactive session
     srun --pty -- /bin/bash
@@ -136,7 +139,8 @@ that these transfers are rate-limited to at most 50 MB/s (total) using
 the ``rsync --bwlimit=50M`` option, and that you run no more than a
 single transfer at a time:
 
-.. code-block:: shell
+.. code-block:: console
+    :class: remote-command
 
     $ rsync -av --progress=summary --bwlimit=50M /from/path/ /to/path/
 
@@ -163,7 +167,8 @@ These transfers *must* be rate-limited to at most 50 MB/s (total) using
 the ``rsync --bwlimit=50M`` option, and you must not run more than a
 single transfer at a time:
 
-.. code-block:: shell
+.. code-block:: console
+    :class: remote-command
 
     $ rsync -av --no-perms --chmod=ugo=rwX --progress=summary --bwlimit=50M /from/path/ /to/path/
 
@@ -189,7 +194,8 @@ interrupted, simply by running ``rsync`` again.
 
 The basic ``rsync`` command you should be using is
 
-.. code-block:: bash
+.. code-block:: console
+    :class: generic-command
 
     rsync -av --progress /copy/this/data/ /to/this/location/
 

--- a/esrum/source/usage/transfers/internal_troubleshooting.rst
+++ b/esrum/source/usage/transfers/internal_troubleshooting.rst
@@ -17,7 +17,8 @@ To fix this, first run the following commands to fix the permissions,
 where ``/path/to/copied/data`` is the path to the copy of the data that
 you have created.
 
-.. code-block::
+.. code-block:: console
+    :class: remote-command
 
     chmod -R +rX,u+w /path/to/copied/data
 

--- a/esrum/source/usage/transfers/services.rst
+++ b/esrum/source/usage/transfers/services.rst
@@ -42,7 +42,8 @@ As there are currently no browsers installed on Esrum, you will need to
 install a copy of Firefox in your home. To do so, perform the following
 steps:
 
-.. code-block:: bash
+.. code-block:: console
+    :class: remote-command
 
     module load pixi/latest
     pixi global install firefox
@@ -51,7 +52,8 @@ Once you have verified that you are connected with both X11-forwarding
 and compression enabled, and you have installed Firefox in your home,
 start an interactive session on Esrum and start Firefox:
 
-.. code-block:: bash
+.. code-block:: console
+    :class: remote-command
 
     srun --pty --x11 -- /bin/bash
     firefox "https://sif.ku.dk/"
@@ -86,6 +88,7 @@ For example, to download the contents of the folder ``my_data`` into a
 project, you might run the following:
 
 .. code-block:: console
+    :class: remote-command
 
     $ mkdir /projects/my_project-AUDIT/data/my_data
     $ cd /projects/my_project-AUDIT/data/my_data

--- a/scripts/rst_checks.py
+++ b/scripts/rst_checks.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# pyright: strict
+from __future__ import annotations
+
+import argparse
+import functools
+import sys
+from pathlib import Path
+
+
+class Errors:
+    def __init__(self) -> None:
+        self._any_errors = False
+
+    def __call__(self, *args: object) -> None:
+        print("ERROR:", *args, file=sys.stderr)
+        self._any_errors = True
+
+    def __bool__(self) -> bool:
+        return self._any_errors
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        formatter_class=functools.partial(
+            argparse.ArgumentDefaultsHelpFormatter,
+            width=79,
+        ),
+        allow_abbrev=False,
+    )
+
+    parser.add_argument("files", nargs="+", type=Path)
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+
+    err = Errors()
+    for filename in sorted(args.files):
+        with filename.open() as handle:
+            in_code_block = False
+            for linenum, line in enumerate(handle, start=1):
+                line = line.strip()
+                if not line:
+                    continue
+
+                if in_code_block:
+                    if line.startswith(":class:"):
+                        in_code_block = False  # produce at most one class related error
+                        _, kind = line.split(":class:", 1)
+                        kind = kind.strip()
+
+                        if not kind:
+                            err(
+                                f"Code-block at '{filename}':{linenum} has empty "
+                                ":class: attribute"
+                            )
+                        elif kind not in (
+                            "remote-command",
+                            "local-command",
+                            "generic-command",
+                        ):
+                            err(
+                                f"Code-block at '{filename}':{linenum} has unexpected "
+                                f":class: attribute: {kind!r}"
+                            )
+
+                    # local-command", ":class: remote-command"):
+                    elif not line.startswith(":"):
+                        in_code_block = False  # produce at most one class related error
+                        err(
+                            f"Code-block at '{filename}':{linenum} has no :class: "
+                            "attribute"
+                        )
+
+                if line.startswith(".. code-block::"):
+                    _, kind = line.rsplit("::", 1)
+                    kind = kind.strip()
+
+                    if not kind:
+                        err(f"Code-block at '{filename}':{linenum} has no format")
+                    elif kind == "console":
+                        in_code_block = True
+                    elif kind not in (
+                        "bash",
+                        "python",
+                        "r",
+                        "text",
+                        "yaml",
+                    ):
+                        err(
+                            f"Code-block at '{filename}':{linenum} has unexpected "
+                            f"format {kind!r}",
+                        )
+                elif line.startswith(".. code::"):  # for consistency/ease of grepping
+                    err(
+                        f"Found `.. code::` block at '{filename}':{linenum}; use "
+                        "`.. code-block::` instead",
+                    )
+
+    return 1 if err else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Add labels to each code block, indicating whether to run it on Esrum or on the user's own computer. Generic commands, runable anywhere, are currently not labeled.

A pre-commit linting script was added to check that all code-blocks are configured correctly.

Some minor text changes were also made, to further reduce the chance of misunderstandings